### PR TITLE
Add RINGS-DX container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,6 @@
+# Singularity/Apptainer specific
 *.sif
+
+# Distributed packages
+*.gz
+*.bz2

--- a/singularity/rings/rings-dx.def
+++ b/singularity/rings/rings-dx.def
@@ -1,0 +1,10 @@
+Bootstrap: docker
+From: nvidia/opengl:1.2-glvnd-devel
+
+%labels
+
+%files
+
+%post
+
+%help

--- a/singularity/rings/rings-dx.def
+++ b/singularity/rings/rings-dx.def
@@ -2,9 +2,46 @@ Bootstrap: docker
 From: nvidia/opengl:1.2-glvnd-devel
 
 %labels
+  Author: Jason C. Nucciarone
+  Maintainer: Jason C. Nucciarone
+  Owner: Jason C. Nucciarone
+  Version: 1.0.0
 
 %files
+  /etc/default/keyboard /etc/default/keyboard
+  dx-4.4.4.tar.gz /opt/dx-4.4.4.tar.gz
+  rings-dx-v1.3.4.tar.bz2 /opt/rings-dx-v1.3.4.tar.bz2
 
 %post
+  export DEBIAN_FRONTEND=noninteractive
+
+  TZ=Etc/UTC && \
+    ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && \
+    echo $TZ > /etc/timezone
+
+  apt update -y
+  apt install -y \
+    locales \
+    git \
+    nano \
+    build-essential \
+    gfortran \
+    x-window-system \
+    libhdf5-dev \
+    libtiff-dev \
+    imagemagick \
+    libnetcdf \
+    openjdk-11-jdk \
+    libjcdf-java \
+    mpich \
+    libmpich-dev \
+    libmotif-common \
+    libmotif-dev
+
+  # TODO: Install OpenDX
+  # TODO: Install RINGS
+  # TODO: Test application on Roar
 
 %help
+  This container is meant to run both RINGS
+  software and OpenDX.

--- a/singularity/rings/rings-dx.def
+++ b/singularity/rings/rings-dx.def
@@ -9,7 +9,7 @@ From: nvidia/opengl:1.2-glvnd-devel
 
 %files
   /etc/default/keyboard /etc/default/keyboard
-  dx-4.4.4.tar.gz /opt/dx-4.4.4.tar.gz
+  automake-1.15.1.tar.gz /opt/automake-1.15.1.tar.gz
   rings-dx-v1.3.4.tar.bz2 /opt/rings-dx-v1.3.4.tar.bz2
 
 %post
@@ -24,23 +24,50 @@ From: nvidia/opengl:1.2-glvnd-devel
     locales \
     git \
     nano \
+    autoconf \
+    bison \
+    byacc \
     build-essential \
     gfortran \
-    x-window-system \
+    flex \
+    xorg \
+    dx \
+    libxpm-dev \
+    libhdf4-dev \
     libhdf5-dev \
     libtiff-dev \
     imagemagick \
-    libnetcdf \
+    libmagickcore-6-headers \
+    libnetcdf-dev \
     openjdk-11-jdk \
-    libjcdf-java \
+    libncurses5-dev \
     mpich \
     libmpich-dev \
     libmotif-common \
     libmotif-dev
 
-  # TODO: Install OpenDX
-  # TODO: Install RINGS
-  # TODO: Test application on Roar
+  CUR_DIR=$(pwd)
+
+  tar -xzvf /opt/automake-1.15.1.tar.gz && \
+    cd automake-1.15.1 && \
+    ./configure --prefix=/opt/aclocal-1.15.1 && \
+    make && \
+    make install && \
+    cd $CUR_DIR && \
+    rm -rf /opt/automake-1.15.1.tar.gz
+
+  export PATH=/opt/aclocal-1.15.1/bin:$PATH
+
+  tar -xjvf /opt/rings-dx-v1.3.4.tar.bz2 && \
+    cd rings-dx/rings-code-v1.3.4 && \
+    ./configure --with-mpi && \
+    automake --add-missing && \
+    make && \
+    make install && \
+    rm -rf /opt/rings-dx-v1.3.4.tar.bz2
+
+%environment
+  export PATH=/opt/aclocal-1.15.1/bin:$PATH
 
 %help
   This container is meant to run both RINGS


### PR DESCRIPTION
Rings is a bit of an older software. Containerized it for a client. Putting her in case any one else needs a RINGS container. **IMPORTANT:** To successfully build the container, you will need the `automake-1.15.1.tar.gz` file and the rings-dx source code from the RINGS website.